### PR TITLE
[CA-104876] Remove resource allocation & IPHelper reliance

### DIFF
--- a/src/xenvif/frontend.c
+++ b/src/xenvif/frontend.c
@@ -1613,8 +1613,15 @@ FrontendInitialize(
                                           *Frontend,
                                           TRUE,
                                           &(*Frontend)->Handle);
-    if (!NT_SUCCESS(status))
-        goto fail12;
+    if (!NT_SUCCESS(status)) {
+        if (status == STATUS_NOT_SUPPORTED) {
+            // If IP Helper isn't available (As in Windows PE)
+            // NotifyUnicastIpAddressChange is not supported
+            Warning("Cannot record or update Network info to XAPI %x\n", 
+                    status);
+        }
+        else goto fail12;
+    }
 
     Trace("<====\n");
 


### PR DESCRIPTION
We don't need to allocate resources, and IPHelper is only used to
know to update the host when IP addresses change.  Both cause problems
under Windows PE

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
