### PR TITLE
Ignore attempts to remove device usage types that were not added.

### DIFF
--- a/src/xenvif/fdo.c
+++ b/src/xenvif/fdo.c
@@ -1536,12 +1536,12 @@ FdoDeviceUsageNotification(
               DeviceUsageTypeName(Type));
         Fdo->Usage[Type]++;
     } else {
-        ASSERT(Fdo->Usage[Type] != 0);
-
-        Trace("%s: REMOVING %s\n",
-              __FdoGetName(Fdo),
-              DeviceUsageTypeName(Type));
-        --Fdo->Usage[Type];
+        if (Fdo->Usage[Type] != 0) {
+            Trace("%s: REMOVING %s\n",
+                  __FdoGetName(Fdo),
+                  DeviceUsageTypeName(Type));
+            --Fdo->Usage[Type];
+        }
     }
 
     status = FdoForwardIrpSynchronously(Fdo, Irp);


### PR DESCRIPTION
ASSERTing on this condition is not particularly helpful as other buggy
software causes BSODs. We should be able to safely ignore and succeed
such IRPs.

Signed-off-by: Paul Durrant paul.durrant@citrix.com
