### PR TITLE
IRP IoStatus.Status and handler returned status should always match.

### DIFF
--- a/src/xenvif/pdo.c
+++ b/src/xenvif/pdo.c
@@ -1146,19 +1146,6 @@ done:
     return status;
 }
 
-static DECLSPEC_NOINLINE NTSTATUS
-PdoQueryResourceRequirements(
-    IN  PXENVIF_PDO                 Pdo,
-    IN  PIRP                        Irp
-    )
-{
-    UNREFERENCED_PARAMETER(Pdo);
-
-    IoCompleteRequest(Irp, IO_NO_INCREMENT);
-
-    return STATUS_SUCCESS;
-}
-
 #define MAXTEXTLEN  128
 
 static DECLSPEC_NOINLINE NTSTATUS
@@ -1560,10 +1547,6 @@ PdoDispatchPnp(
 
     case IRP_MN_QUERY_CAPABILITIES:
         status = PdoQueryCapabilities(Pdo, Irp);
-        break;
-
-    case IRP_MN_QUERY_RESOURCE_REQUIREMENTS:
-        status = PdoQueryResourceRequirements(Pdo, Irp);
         break;
 
     case IRP_MN_QUERY_DEVICE_TEXT:


### PR DESCRIPTION
When the guts of the handler for IRP_MN_QUERY_RESOURCE_REQUIREMENTS were
ripped out the remaining code unconditionally returned STATUS_SUCCESS whilst
the IRP was almost certainly preloaded with STATUS_NOT_SUPPORTED. To fix,
simply stop handling that IRP and the dispatcher default clause DTRT.

Signed-off-by: Paul Durrant paul.durrant@citrix.com
