### PR TITLE
Useful code added while debugging WHQL issues:

### DIFF
--- a/include/tcpip.h
+++ b/include/tcpip.h
@@ -37,6 +37,7 @@
 #pragma warning(push)
 #pragma warning(disable:4214) // nonstandard extension used : bit field types other than int
 #pragma warning(disable:4201) // nonstandard extension used : nameless struct/union
+#pragma warning(disable:4200) // nonstandard extension used : zero-sized array in struct/union
 
 #pragma pack(push, 1)
 
@@ -258,6 +259,19 @@ typedef struct _ICMPV6_HEADER {
 #define ICMPV6_TYPE_RA  134
 #define ICMPV6_TYPE_NS  135
 #define ICMPV6_TYPE_NA  136
+
+#define IPPROTO_AH          51
+
+// AH
+
+typedef struct _IP_AUTHENTICATION_HEADER {
+    UCHAR   NextHeader;
+    UCHAR   Length;
+    USHORT  Reserved;
+    ULONG   Spi;
+    ULONG   Seq;
+    UCHAR   Icv[0];
+} IP_AUTHENTICATION_HEADER, *PIP_AUTHENTICATION_HEADER;
 
 #define IPPROTO_NONE        59
 

--- a/src/xenvif/checksum.c
+++ b/src/xenvif/checksum.c
@@ -289,13 +289,13 @@ ChecksumTcpPacket(
         PIPV4_HEADER    Version4 = &IpHeader->Version4;
         
         Length = NTOHS(Version4->PacketLength) -
-                 sizeof (IPV4_HEADER) -
-                 (USHORT)Info->IpOptions.Length;
+                 Info->IpHeader.Length -
+                 Info->IpOptions.Length;
     } else {
         PIPV6_HEADER    Version6 = &IpHeader->Version6;
 
         Length = NTOHS(Version6->PayloadLength) -
-                 (USHORT)Info->IpOptions.Length;
+                 Info->IpOptions.Length;
     }
 
     Length -= Info->TcpHeader.Length;

--- a/src/xenvif/notifier.c
+++ b/src/xenvif/notifier.c
@@ -511,6 +511,8 @@ NotifierDisconnect(
     ASSERT(Notifier->Connected);
     Notifier->Connected = FALSE;
 
+    Notifier->Split = FALSE;
+
     STORE(Release, Notifier->StoreInterface);
     Notifier->StoreInterface = NULL;
 


### PR DESCRIPTION
- Tidied up receiver xenstore feature advertisement
- Added registry options to turn off GSO at the transmitter
- Added an 'always copy' option to the transmtter
- Added AH option parsing for IPv6
- Added code to drop oversize non-GSO packets at receiver
- Added some more error DbgPrints
- Added large packet stats to the receiver

Signed-off-by: Paul Durrant paul.durrant@citrix.com
