### PR TITLE
[CA-135514] Netio imports can fail

### DIFF
--- a/src/xenvif/netio.c
+++ b/src/xenvif/netio.c
@@ -38,7 +38,7 @@
 #include "dbg_print.h"
 #include "assert.h"
 
-LONG    NetioReferences;
+LONG    NetioReferences = 0;
 PVOID   NetioGetUnicastIpAddressTable;
 PVOID   NetioNotifyUnicastIpAddressChange;
 PVOID   NetioCancelMibChangeNotify2;

--- a/src/xenvif/netio.c
+++ b/src/xenvif/netio.c
@@ -219,6 +219,12 @@ found:
 
     __NetioFree(QueryInfo);
 
+    if (NetioGetUnicastIpAddressTable == NULL ||
+        NetioNotifyUnicastIpAddressChange == NULL ||
+        NetioCancelMibChangeNotify2 == NULL ||
+        NetioFreeMibTable == NULL)
+        goto retry;
+
 done:
     ASSERT(NetioGetUnicastIpAddressTable != NULL);
     ASSERT(NetioNotifyUnicastIpAddressChange != NULL);
@@ -246,6 +252,16 @@ fail2:
 
 fail1:
     Error("fail1 (%08x)\n", status);
+
+    (VOID) InterlockedDecrement(&NetioReferences);
+
+    return status;
+
+retry:
+    NetioGetUnicastIpAddressTable = NULL;
+    NetioNotifyUnicastIpAddressChange = NULL;
+    NetioCancelMibChangeNotify2 = NULL;
+    NetioFreeMibTable = NULL;
 
     (VOID) InterlockedDecrement(&NetioReferences);
 

--- a/src/xenvif/netio.c
+++ b/src/xenvif/netio.c
@@ -265,7 +265,7 @@ retry:
 
     (VOID) InterlockedDecrement(&NetioReferences);
 
-    return status;
+    return STATUS_RETRY;
 }
 
 VOID


### PR DESCRIPTION
Netio imports can fail to get some/all imports after loading netio.sys. This will result in an ASSERT fail (checked build) or SYSTEM_THREAD_EXCEPTION_NOT_HANDLED BSOD when first calling a netio function (release build).
