### PR TITLE
Treat a missing Aliases value as an empty one

### DIFF
--- a/src/xenvif/pdo.c
+++ b/src/xenvif/pdo.c
@@ -1051,11 +1051,17 @@ __PdoCheckForAlias(
     AliasesKey = DriverGetAliasesKey();
     ASSERT(AliasesKey != NULL);
 
+    Alias = NULL;
+
     status = RegistryQuerySzValue(AliasesKey,
                                   __PdoGetName(Pdo),
                                   &Alias);
-    if (!NT_SUCCESS(status))
+    if (!NT_SUCCESS(status)) {
+        if (status == STATUS_OBJECT_NAME_NOT_FOUND)
+            goto done;
+
         goto fail2;
+    }
 
     if (Alias->Length == 0)   // No alias
         goto done;
@@ -1089,7 +1095,8 @@ __PdoCheckForAlias(
     EMULATED(Release, EmulatedInterface);
     
 done:
-    RegistryFreeSzValue(Alias);
+    if (Alias != NULL)
+        RegistryFreeSzValue(Alias);
 
     return STATUS_SUCCESS;
 


### PR DESCRIPTION
There are certain cases when xennet's co-installer may not have run so
we end up trying to (safely) start PDOs without even an empty alias.

Signed-off-by: Paul Durrant paul.durrant@citrix.com
