### PR TITLE
Mark xenvif driver as boot-start

### DIFF
--- a/src/xenvif.inf
+++ b/src/xenvif.inf
@@ -73,7 +73,7 @@ AddService=xenvif,0x02,XenVif_Service,
 
 [XenVif_Service] 
 ServiceType=%SERVICE_KERNEL_DRIVER% 
-StartType=%SERVICE_DEMAND_START% 
+StartType=%SERVICE_BOOT_START%
 ErrorControl=%SERVICE_ERROR_NORMAL% 
 ServiceBinary=%12%\xenvif.sys 
 LoadOrderGroup="NDIS"


### PR DESCRIPTION
For iSCSI boot, xenvif.sys needs to be explicitly marked as a
boot-start driver.

Signed-off-by: Michael Brown mbrown@fensystems.co.uk
