### PR TITLE
Promote xenvif.sys to be a boot start driver on network boot

### DIFF
--- a/src/xenvif.inf
+++ b/src/xenvif.inf
@@ -77,13 +77,16 @@ StartType=%SERVICE_DEMAND_START%
 ErrorControl=%SERVICE_ERROR_NORMAL% 
 ServiceBinary=%12%\xenvif.sys 
 LoadOrderGroup="NDIS"
-AddReg = XenVif_Parameters, XenVif_Aliases
+AddReg = XenVif_Parameters, XenVif_Aliases, XenVif_BootFlags
 
 [XenVif_Parameters]
 HKR,"Parameters",,0x00000010
 
 [XenVif_Aliases]
 HKR,"Aliases",,0x00000010
+
+[XenVif_BootFlags]
+HKR,,BootFlags,0x00010003,0x01 ; CM_SERVICE_NETWORK_BOOT_LOAD
 
 [XenVif_Inst.CoInstallers]
 CopyFiles=CoInst_CopyFiles


### PR DESCRIPTION
Signed-off-by: Michael Brown mbrown@fensystems.co.uk
